### PR TITLE
Update proposal for dict syntax, templating of zones, and a configurable dir for zone files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ it has the following features:
 
 - allows to store zone data in "classical" zone files, instead of having to write
   zones as ansible variables like [here](https://github.com/reallyenglish/ansible-role-nsd)
+- also allow zone data Jinja, in case you need something more dynamic
 - supports both master and slave scenarios, or even a mixture of both
   (some zones running as master and some zones running as slave, on the same
   NSD server)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 nsd_primary_zones: []
 nsd_secondary_zones: []
 nsd_tsig_keys: []
+nsd_local_zones_dir: files/nsd/
 
 # Default variables, suitable for nsd4 on Debian (jessie or above)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Install nsd
-  apt:
-    pkg: "{{ nsd_pkg_name }}"
+  package:
+    name: "{{ nsd_pkg_name }}"
     state: present
 
 - name: Create primary zone directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Copy content of primary zones
   template:
-    src: "files/nsd/{{ item.zone_filename }}"
+    src: "{{ nsd_local_zones_dir }}/{{ item.zone_filename }}"
     dest: "{{ nsd_primary_zones_dir }}/{{ item.zone_filename }}"
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     - restart nsd
 
 - name: Copy content of primary zones
-  copy: 
+  template:
     src: "files/nsd/{{ item.zone_filename }}"
     dest: "{{ nsd_primary_zones_dir }}/{{ item.zone_filename }}"
     owner: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install nsd
   package:
     name: "{{ nsd_pkg_name }}"
@@ -20,7 +19,6 @@
     owner: nsd
     group: nsd
     mode: "0755"
-
 
 - name: Configure nsd zones
   template:
@@ -45,7 +43,6 @@
   validate: 'nsd-checkconf %s'
   notify:
     - restart nsd
-
 
 - name: Copy content of primary zones
   copy: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,31 +1,59 @@
 ---
 
 - name: Install nsd
-  apt: pkg={{ nsd_pkg_name }} state=present
-
+  apt:
+    pkg: "{{ nsd_pkg_name }}"
+    state: present
 
 - name: Create primary zone directory
-  file: path="{{ nsd_primary_zones_dir }}" state=directory owner=root group=root mode=0755
+  file:
+    path: "{{ nsd_primary_zones_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
 
 - name: Create secondary zone directory
-  file: path="{{ nsd_secondary_zones_dir }}" state=directory owner=nsd group=nsd mode=0755
+  file:
+    path: "{{ nsd_secondary_zones_dir }}"
+    state: directory
+    owner: nsd
+    group: nsd
+    mode: "0755"
 
 
 - name: Configure nsd zones
-  template: src=zones_config.j2 dest="{{ nsd_zones_config_file }}" owner=root group=root mode=0644 validate='nsd-checkconf %s'
+  template:
+    src: zones_config.j2
+    dest: "{{ nsd_zones_config_file }}"
+    owner: root
+    group: root
+    mode: 0644
+    validate: 'nsd-checkconf %s'
   notify:
     - rebuild nsd database
     - reload nsd database
     - restart nsd
 
 - name: Create base nsd configuration file
-  template: src=config.j2 dest="{{ nsd_config_dir }}/nsd.conf" owner=root group=root mode=0644 validate='nsd-checkconf %s'
+  template:
+  src: config.j2
+  dest: "{{ nsd_config_dir }}/nsd.conf"
+  owner: root
+  group: root
+  mode: "0644"
+  validate: 'nsd-checkconf %s'
   notify:
     - restart nsd
 
 
 - name: Copy content of primary zones
-  copy: src="files/nsd/{{ item.zone_filename }}" dest="{{ nsd_primary_zones_dir }}/{{ item.zone_filename }}" owner=root group=root mode=0644
+  copy: 
+    src: "files/nsd/{{ item.zone_filename }}"
+    dest: "{{ nsd_primary_zones_dir }}/{{ item.zone_filename }}"
+    owner: root
+    group: root
+    mode: "0644"
   with_items: "{{ nsd_primary_zones }}"
   notify:
     - rebuild nsd database


### PR DESCRIPTION
Hi,

Here's a proposed update that includes a few different things that would be nice, if you're open to such PRs, that is:

- use the dictionnary syntax for tasks
- change apt to package to make the script at least seemingly suitable for more than Debian (I doubt it would work as is, though)
- change the module for zone files to be template, so we can use jinja in zone files
- add a new default nsd_local_zones_dir to set the local dir used to look for zone templates/files

We can also maybe make it so we have either files or templates, rather than considering them all templates, and check more than one directory for files as well… But I guess it's not too bad already ;)

Thanks for your role, it was a good starting point for ansible-ing nsd!

Cheers
Gilou